### PR TITLE
terminal: missing GETTEXT_PACKAGE variable in gschema.xml.in file

### DIFF
--- a/plugins/terminal/org.mate.pluma.plugins.terminal.gschema.xml.in
+++ b/plugins/terminal/org.mate.pluma.plugins.terminal.gschema.xml.in
@@ -11,7 +11,7 @@
     <value nick='underline' value='2'/>
   </enum>
 
-  <schema gettext-domain="pluma-plugins" id="org.mate.pluma.plugins.terminal" path="/org/mate/pluma/plugins/terminal/">
+  <schema gettext-domain="@GETTEXT_PACKAGE@" id="org.mate.pluma.plugins.terminal" path="/org/mate/pluma/plugins/terminal/">
     <key name="silent-bell" type="b">
       <default>true</default>
       <summary>Whether to silence terminal bell</summary>


### PR DESCRIPTION
Test:
```
$ grep gettext-domain plugins/terminal/org.mate.pluma.plugins.terminal.gschema.xml
  <schema gettext-domain="pluma-plugins" id="org.mate.pluma.plugins.terminal" path="/org/mate/pluma/plugins/terminal/">
```
plugins/terminal/org.mate.pluma.plugins.terminal.gschema.xml is an output file of configure script, which replaces the variable `@GETTEXT_PACKAGE@` in configure stage.