### PR TITLE
bookmarks: remove an unnecessary assignment

### DIFF
--- a/plugins/bookmarks/pluma-bookmarks-plugin.c
+++ b/plugins/bookmarks/pluma-bookmarks-plugin.c
@@ -798,7 +798,6 @@ save_bookmark_metadata (PlumaView *view)
 	if (string->len == 0)
 	{
 		val = g_string_free (string, TRUE);
-		val = NULL;
 	}
 	else
 	{


### PR DESCRIPTION
`g_string_free (string, free_segment)` returns `NULL` if `free_segment` is `TRUE`
https://docs.gtk.org/glib/method.String.free.html