### PR TITLE
Fix synctex plugin dependency detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,24 +128,18 @@ then
 	# ================================================================
 	# Synctex (dbus-python)
 	# ================================================================
-	DBUSPYTHON_REQUIRED=0.82
-	PKG_CHECK_MODULES([DBUSPYTHON],
-		[dbus-python >= $DBUSPYTHON_REQUIRED],
-		[have_synctex=yes],
-		[have_synctex=no])
-
-	AC_SUBST([DBUS_PYTHON_CFLAGS])
-	AC_SUBST([DBUS_PYTHON_LIBS])
-
 	AC_MSG_CHECKING([for synctex dependency dbus-python])
-	AC_MSG_RESULT($have_synctex)
 
-	if test "x$have_synctex" = "xyes"; then
+	if `$PYTHON -c "import dbus" 2>/dev/null`;
+	then
+		have_synctex=yes
 		PLUGINS="$PLUGINS synctex"
 	else
-		AC_MSG_RESULT([yes])
+		have_synctex=no
 		disabled_plugins="$disabled_plugins synctex (dbus-python not found)"
 	fi
+
+	AC_MSG_RESULT($have_synctex)
 
 	# ================================================================
 	# Terminal (vte)


### PR DESCRIPTION
The synctex plugin depends on the Python dbus module, but only during run-time. The plugin is Python code only, thus there is no need to check for `/usr/include/dbus-1.0/dbus/dbus-python.h` or `pkgconfig(dbus-python)`.

For downstream usage, existing build instructions need to be updated properly, e.g. in a `*.spec` file

```
BuildRequires: dbus-python-devel
```

needs to be come

```
BuildRequires: python3-dbus
Requires:      python3-dbus
```

Successful test scenario:

1. Install LaTeX environment
    - Fedora: `dnf install texlive-scheme-basic`
3. Start Pluma
4. Enable "SyncTeX" plugin in settings
5. Open a LaTeX file (`*.tex`)
6. Ctrl + Left Mouse Button click on a LaTeX command
7. Atril should show the file and mark the clicked section