### PR TITLE
markdown-preview: Add Markdown preview plugin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,7 +89,7 @@ GLIB_GSETTINGS
 C_PLUGINS="bookmarks quickhighlight sourcecodebrowser wordcompletion"
 
 # Python plugins that don't need special dependencies, besides Python
-PYTHON_PLUGINS="bracketcompletion codecomment smartspaces"
+PYTHON_PLUGINS="bracketcompletion codecomment markdown-preview smartspaces"
 
 PLUGINS="$C_PLUGINS"
 disabled_plugins=""
@@ -213,6 +213,9 @@ plugins/Makefile
 plugins/codecomment/codecomment.plugin.desktop.in
 plugins/codecomment/Makefile
 plugins/codecomment/pluma-codecomment.metainfo.xml.in
+plugins/markdown-preview/markdown-preview.plugin.desktop.in
+plugins/markdown-preview/Makefile
+plugins/markdown-preview/pluma-markdown-preview.metainfo.xml.in
 plugins/smartspaces/smartspaces.plugin.desktop.in
 plugins/smartspaces/Makefile
 plugins/sourcecodebrowser/Makefile

--- a/help/Makefile.am
+++ b/help/Makefile.am
@@ -1,6 +1,6 @@
 @YELP_HELP_RULES@
 
-PLUGINS_WITHOUT_HELP = quickhighlight smartspaces sourcecodebrowser
+PLUGINS_WITHOUT_HELP = markdown-preview quickhighlight smartspaces sourcecodebrowser
 HELP_ID = pluma-plugins
 HELP_FILES = index.page legal-plugins.xml $(foreach plugin,$(filter-out $(PLUGINS_WITHOUT_HELP),$(PLUGINS)),$(plugin).page)
 HELP_MEDIA = figures/pluma-icon.png \

--- a/meson.build
+++ b/meson.build
@@ -84,6 +84,13 @@ else
   disabled_plugins += 'synctex'
 endif
 
+if get_option('plugin_markdown_preview')
+  enabled_plugins += 'markdown-preview'
+  extra_languages += 'python'
+else
+  disabled_plugins += 'markdown-preview'
+endif
+
 if 'python' in extra_languages
   python3 = python.find_installation('python3')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,7 @@
 option('plugin_bookmarks', type: 'boolean')
 option('plugin_bracketcompletion', type: 'boolean')
 option('plugin_codecomment', type: 'boolean')
+option('plugin_markdown_preview', type: 'boolean')
 option('plugin_quickhighlight', type: 'boolean')
 option('plugin_smartspaces', type: 'boolean')
 option('plugin_sourcecodebrowser', type: 'boolean')

--- a/plugins/markdown-preview/Makefile.am
+++ b/plugins/markdown-preview/Makefile.am
@@ -1,0 +1,32 @@
+# Markdown Preview Plugin
+
+plugindir = $(PLUMA_PLUGINS_LIBS_DIR)
+plugin_PYTHON =		\
+	markdown_preview.py
+
+plugin_in_files = markdown-preview.plugin.desktop.in
+plugin_DATA = $(plugin_in_files:.desktop.in=)
+
+$(plugin_DATA): $(plugin_in_files)
+	$(AM_V_GEN) $(MSGFMT) --keyword=Name --keyword=Description --desktop --template $< -d $(top_srcdir)/po -o $@
+
+metainfodir = $(datadir)/metainfo
+metainfo_DATA = pluma-markdown-preview.metainfo.xml
+metainfo_in_files = $(metainfo_DATA:=.in)
+
+$(metainfo_DATA): $(metainfo_in_files)
+	$(AM_V_GEN) GETTEXTDATADIR=$(top_srcdir) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
+
+EXTRA_DIST = \
+	$(metainfo_in_files:=.in) \
+	$(plugin_in_files:=.in)
+
+CLEANFILES = \
+	$(metainfo_DATA) \
+	$(plugin_DATA)
+
+DISTCLEANFILES = \
+	$(metainfo_in_files) \
+	$(plugin_in_files)
+
+-include $(top_srcdir)/git.mk

--- a/plugins/markdown-preview/markdown-preview.plugin.desktop.in.in
+++ b/plugins/markdown-preview/markdown-preview.plugin.desktop.in.in
@@ -1,0 +1,12 @@
+[Plugin]
+Loader=python3
+Module=markdown_preview
+IAge=2
+Name=Markdown Preview
+Description=Live preview of Markdown files in the right panel
+# Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+Icon=text-x-markdown
+Authors=MATE Development Team
+Copyright=Copyright @ 2025 MATE Development Team
+Website=@PACKAGE_URL@
+Version=@VERSION@

--- a/plugins/markdown-preview/markdown_preview.py
+++ b/plugins/markdown-preview/markdown_preview.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Pluma Markdown Preview Plugin
+
+A markdown preview plugin for Pluma text editor using WebKit2.
+"""
+
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('Pluma', '1.0')
+gi.require_version('WebKit2', '4.1')
+
+from gi.repository import Gtk, Gio, Pluma, GObject, WebKit2
+import html as html_module
+
+try:
+    import markdown
+    MARKDOWN_AVAILABLE = True
+except ImportError:
+    MARKDOWN_AVAILABLE = False
+
+
+class PlumaMarkdownPreviewPlugin(GObject.Object, Pluma.WindowActivatable):
+    """Markdown Preview Plugin for Pluma"""
+
+    __gtype_name__ = "PlumaMarkdownPreviewPlugin"
+    window = GObject.property(type=Pluma.Window)
+
+    def __init__(self):
+        GObject.Object.__init__(self)
+        self._preview_widget = None
+        self._webview = None
+        self._update_timer = None
+        self._available_extensions = None  # Cache for detected extensions
+
+    def do_activate(self):
+        if not MARKDOWN_AVAILABLE:
+            return
+
+        self._create_preview_widget()
+        self._add_menu_items()
+
+    def do_deactivate(self):
+        if not MARKDOWN_AVAILABLE:
+            return
+
+        self._remove_preview_widget()
+        self._remove_menu_items()
+
+    def do_update_state(self):
+        """Update plugin state when document changes"""
+        doc = self.window.get_active_document()
+        if doc and self._is_markdown_file(doc):
+            self._show_preview()
+            self._schedule_update()
+        else:
+            self._load_welcome_content()
+
+    def _create_preview_widget(self):
+        """Create the preview widget with WebKit2"""
+        if self._preview_widget:
+            return
+
+        # Create scrolled window container
+        self._preview_widget = Gtk.ScrolledWindow()
+        self._preview_widget.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+
+        # Create WebKit2 webview
+        self._webview = WebKit2.WebView()
+        self._webview.connect("decide-policy", self._on_decide_policy)
+
+        # Load initial content
+        self._load_welcome_content()
+
+        self._preview_widget.add(self._webview)
+        self._preview_widget.show_all()
+
+        # Add to right panel
+        panel = self.window.get_right_panel()
+        icon_theme = Gtk.IconTheme.get_default()
+        if icon_theme.has_icon("text-x-markdown"):
+            icon_name = "text-x-markdown"
+        else:
+            icon_name = "text-x-generic"
+        icon = Gtk.Image.new_from_icon_name(icon_name, Gtk.IconSize.MENU)
+        panel.add_item(self._preview_widget, "Markdown Preview", icon)
+
+    def _remove_preview_widget(self):
+        """Remove the preview widget"""
+        if self._preview_widget:
+            panel = self.window.get_right_panel()
+            panel.remove_item(self._preview_widget)
+            self._preview_widget = None
+            self._webview = None
+
+    def _add_menu_items(self):
+        """Add menu items to Tools menu"""
+        manager = self.window.get_ui_manager()
+
+        # Create action group
+        self._action_group = Gtk.ActionGroup("MarkdownPreviewActions")
+
+        # Add preview action
+        preview_action = Gtk.Action("MarkdownPreview", "Show Markdown Preview",
+                                    "Preview the current markdown document", None)
+        preview_action.connect("activate", self._on_preview_activate)
+        self._action_group.add_action(preview_action)
+
+        # Add update action
+        update_action = Gtk.Action("MarkdownUpdate", "Update Markdown Preview",
+                                   "Update the markdown preview", None)
+        update_action.connect("activate", self._on_update_activate)
+        self._action_group.add_action(update_action)
+
+        manager.insert_action_group(self._action_group, -1)
+
+        # Add UI elements
+        self._ui_id = manager.new_merge_id()
+        manager.add_ui(self._ui_id, "/MenuBar/ToolsMenu/ToolsOps_4",
+                       "MarkdownPreview", "MarkdownPreview",
+                       Gtk.UIManagerItemType.MENUITEM, False)
+        manager.add_ui(self._ui_id, "/MenuBar/ToolsMenu/ToolsOps_4",
+                       "MarkdownUpdate", "MarkdownUpdate",
+                       Gtk.UIManagerItemType.MENUITEM, False)
+
+    def _remove_menu_items(self):
+        if hasattr(self, '_ui_id'):
+            manager = self.window.get_ui_manager()
+            manager.remove_ui(self._ui_id)
+            manager.remove_action_group(self._action_group)
+
+    def _on_decide_policy(self, webview, decision, decision_type):
+        """Open clicked links in the default browser instead of the preview"""
+        if decision_type in (WebKit2.PolicyDecisionType.NAVIGATION_ACTION,
+                             WebKit2.PolicyDecisionType.NEW_WINDOW_ACTION):
+            nav_action = decision.get_navigation_action()
+            if nav_action.get_navigation_type() == WebKit2.NavigationType.LINK_CLICKED:
+                uri = nav_action.get_request().get_uri()
+                Gio.AppInfo.launch_default_for_uri(uri, None)
+                decision.ignore()
+                return True
+        return False
+
+    def _on_preview_activate(self, action):
+        panel = self.window.get_right_panel()
+        panel.show()
+        panel.activate_item(self._preview_widget)
+        self._update_preview()
+
+    def _on_update_activate(self, action):
+        """Force update the preview"""
+        self._update_preview()
+
+    def _is_markdown_file(self, doc):
+        """Check if document is a markdown file"""
+        if not doc:
+            return False
+
+        # Check by language
+        lang = doc.get_language()
+        if lang and lang.get_id() == "markdown":
+            return True
+
+        # Check by filename
+        location = doc.get_location()
+        if location:
+            filename = location.get_basename()
+            if filename:
+                name_lower = filename.lower()
+                return any(name_lower.endswith(ext) for ext in
+                          ['.md', '.markdown'])
+
+        return False
+
+    def _show_preview(self):
+        """Activate the preview tab if the panel is already visible"""
+        panel = self.window.get_right_panel()
+        if panel.get_visible() and not panel.item_is_active(self._preview_widget):
+            panel.activate_item(self._preview_widget)
+
+    def _schedule_update(self):
+        """Schedule a preview update with debouncing"""
+        panel = self.window.get_right_panel()
+        if not panel.get_visible() or not panel.item_is_active(self._preview_widget):
+            return
+
+        if self._update_timer:
+            GObject.source_remove(self._update_timer)
+        self._update_timer = GObject.timeout_add(500, self._update_preview)
+
+    def _update_preview(self):
+        """Update the markdown preview"""
+        doc = self.window.get_active_document()
+        if not doc or not self._is_markdown_file(doc):
+            self._load_welcome_content()
+            return False
+
+        # Get document text
+        start = doc.get_start_iter()
+        end = doc.get_end_iter()
+        text = doc.get_text(start, end, True)
+
+        if not text.strip():
+            self._load_welcome_content()
+            return False
+
+        # Convert markdown to HTML
+        html = self._markdown_to_html(text)
+
+        # Load in webview
+        self._webview.load_html(html, None)
+
+        self._update_timer = None
+        return False
+
+    def _detect_available_extensions(self):
+        """Detect which markdown extensions are available and working"""
+        # Extensions to test for availability
+        extensions = [
+            'extra',      # Compilation of Python-Markdown extensions
+            'admonition', # Warning/note boxes
+            'codehilite', # Code highlighting
+            'nl2br',      # Newline to break
+            'smarty',     # Smart quotes
+            'toc',        # Table of contents
+        ]
+
+        available = []
+        test_text = "# Test\n\nTest text."
+
+        # Test each extension individually
+        for ext in extensions:
+            try:
+                markdown.markdown(test_text, extensions=[ext])
+                available.append(ext)
+            except Exception:
+                pass
+
+        return available
+
+
+    def _markdown_to_html(self, text):
+        try:
+            # Detect available extensions (cached after first run)
+            if self._available_extensions is None:
+                self._available_extensions = self._detect_available_extensions()
+
+            # Convert markdown with detected extensions
+            html_content = markdown.markdown(text, extensions=self._available_extensions)
+
+            # Wrap in full HTML document
+            html = f"""
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Markdown Preview</title>
+    <style>
+        body {{
+            font-family: sans-serif;
+            line-height: 1.5;
+            color: #2e3436;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 1rem;
+            background: white;
+        }}
+        pre {{
+            background: #eeeeec;
+            border: 1px solid #babdb6;
+            padding: 0.5rem;
+            overflow-x: auto;
+        }}
+        code {{
+            background: #eeeeec;
+            padding: 2px 4px;
+        }}
+        blockquote {{
+            margin: 0;
+            padding-left: 1rem;
+            border-left: 3px solid #888A85;
+            color: #888A85;
+        }}
+        table {{
+            border-collapse: collapse;
+        }}
+        th, td {{
+            border: 1px solid #babdb6;
+            padding: 0.5rem;
+        }}
+        th {{
+            background: #eeeeec;
+        }}
+        a {{
+            color: #3465a4;
+        }}
+        /* Admonitions */
+        .admonition {{
+            margin: 0.5rem 0;
+            padding: 0.1rem 1rem;
+            background: #eeeeec;
+            border-left: 3px solid #729fcf;
+        }}
+        .admonition.warning {{
+            border-left-color: #f57900;
+        }}
+        .admonition.danger, .admonition.error {{
+            border-left-color: #cc0000;
+        }}
+        .admonition-title {{
+            font-weight: bold;
+        }}
+    </style>
+</head>
+<body>
+    {html_content}
+</body>
+</html>
+"""
+            return html
+
+        except Exception as e:
+            escaped = html_module.escape(text)
+            return f"<html><body><h1>Markdown Error</h1><p>Error converting markdown: {html_module.escape(str(e))}</p><pre>{escaped}</pre></body></html>"
+
+    def _load_welcome_content(self):
+        """Load welcome content when no markdown is active"""
+        welcome_html = """
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Markdown Preview</title>
+    <style>
+        body {
+            font-family: system-ui, sans-serif;
+            text-align: center;
+            padding: 2rem;
+            color: #2e3436;
+            background: #ffffff;
+        }
+    </style>
+</head>
+<body>
+    <h2>Markdown Preview</h2>
+    <p>Open a markdown file (.md, .markdown) to see the preview here.</p>
+    <p><small>This is a markdown preview plugin for Pluma</small></p>
+</body>
+</html>
+"""
+        if self._webview:
+            self._webview.load_html(welcome_html, None)

--- a/plugins/markdown-preview/markdown_preview.py
+++ b/plugins/markdown-preview/markdown_preview.py
@@ -34,6 +34,8 @@ class PlumaMarkdownPreviewPlugin(GObject.Object, Pluma.WindowActivatable):
         self._webview = None
         self._update_timer = None
         self._available_extensions = None  # Cache for detected extensions
+        self._connected_doc = None
+        self._changed_handler = None
 
     def do_activate(self):
         if not MARKDOWN_AVAILABLE:
@@ -46,17 +48,40 @@ class PlumaMarkdownPreviewPlugin(GObject.Object, Pluma.WindowActivatable):
         if not MARKDOWN_AVAILABLE:
             return
 
+        self._disconnect_document()
         self._remove_preview_widget()
         self._remove_menu_items()
 
     def do_update_state(self):
         """Update plugin state when document changes"""
         doc = self.window.get_active_document()
+        self._connect_document(doc)
         if doc and self._is_markdown_file(doc):
             self._show_preview()
             self._schedule_update()
         else:
             self._load_welcome_content()
+
+    def _connect_document(self, doc):
+        """Connect to the document's changed signal for live updates"""
+        if self._connected_doc == doc:
+            return
+        self._disconnect_document()
+        if doc:
+            self._connected_doc = doc
+            self._changed_handler = doc.connect("changed", self._on_document_changed)
+
+    def _disconnect_document(self):
+        """Disconnect from the current document's changed signal"""
+        if self._connected_doc and self._changed_handler:
+            self._connected_doc.disconnect(self._changed_handler)
+        self._connected_doc = None
+        self._changed_handler = None
+
+    def _on_document_changed(self, doc):
+        """Called on every text change in the active document"""
+        if self._is_markdown_file(doc):
+            self._schedule_update()
 
     def _create_preview_widget(self):
         """Create the preview widget with WebKit2"""
@@ -206,11 +231,22 @@ class PlumaMarkdownPreviewPlugin(GObject.Object, Pluma.WindowActivatable):
             self._load_welcome_content()
             return False
 
-        # Convert markdown to HTML
-        html = self._markdown_to_html(text)
+        location = doc.get_location()
+        base_uri = location.get_uri() if location else None
 
-        # Load in webview
-        self._webview.load_html(html, None)
+        def on_scroll_saved(webview, result, user_data):
+            try:
+                js_result = webview.run_javascript_finish(result)
+                scroll_y = js_result.get_js_value().to_int32()
+            except Exception:
+                scroll_y = 0
+            self._webview.load_html(self._markdown_to_html(text, scroll_y), base_uri)
+
+        # Save scroll position before reloading, then render in callback
+        self._webview.run_javascript(
+            "document.documentElement.scrollTop || document.body.scrollTop",
+            None, on_scroll_saved, None
+        )
 
         self._update_timer = None
         return False
@@ -241,7 +277,7 @@ class PlumaMarkdownPreviewPlugin(GObject.Object, Pluma.WindowActivatable):
         return available
 
 
-    def _markdown_to_html(self, text):
+    def _markdown_to_html(self, text, scroll_y=0):
         try:
             # Detect available extensions (cached after first run)
             if self._available_extensions is None:
@@ -316,6 +352,7 @@ class PlumaMarkdownPreviewPlugin(GObject.Object, Pluma.WindowActivatable):
 </head>
 <body>
     {html_content}
+    <script>document.addEventListener('DOMContentLoaded', function() {{ window.scrollTo(0, {scroll_y}); }});</script>
 </body>
 </html>
 """

--- a/plugins/markdown-preview/meson.build
+++ b/plugins/markdown-preview/meson.build
@@ -1,0 +1,55 @@
+markdown_preview_sources = files(
+  'markdown_preview.py',
+)
+
+install_data(
+  markdown_preview_sources,
+  install_dir: join_paths(
+    pkglibdir,
+    'plugins',
+  )
+)
+
+markdown_preview_plugin_in = configure_file(
+  input: 'markdown-preview.plugin.desktop.in.in',
+  output: 'markdown-preview.plugin.desktop.in',
+  configuration: plugin_in,
+  install: false,
+)
+
+markdown_preview_plugin = custom_target(
+  'markdown-preview.plugin',
+  input: markdown_preview_plugin_in,
+  output: 'markdown-preview.plugin',
+  command: msgfmt_plugin_cmd,
+  install: true,
+  install_dir: join_paths(
+    pkglibdir,
+    'plugins',
+  )
+)
+
+markdown_preview_metainfo = i18n.merge_file(
+  input : configure_file(
+    configuration: plugin_in,
+    input : 'pluma-markdown-preview.metainfo.xml.in.in',
+    output: 'pluma-markdown-preview.metainfo.xml.in'
+  ),
+  output: 'pluma-markdown-preview.metainfo.xml',
+  po_dir: join_paths(srcdir, 'po'),
+  type: 'xml',
+  install: true,
+  install_dir: appstreamdir,
+)
+
+if appstream_util.found()
+  test(
+    'validate-pluma-markdown-preview.metainfo.xml',
+    appstream_util,
+    args: [
+      'validate-relax',
+      '--nonet',
+      markdown_preview_metainfo.full_path(),
+    ]
+  )
+endif

--- a/plugins/markdown-preview/pluma-markdown-preview.metainfo.xml.in.in
+++ b/plugins/markdown-preview/pluma-markdown-preview.metainfo.xml.in.in
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2025 MATE Development Team -->
+<component type="addon">
+  <id>pluma-markdown-preview</id>
+  <extends>org.mate.pluma.desktop</extends>
+  <name>Markdown Preview</name>
+  <summary>Live preview of Markdown files in Pluma</summary>
+  <url type="homepage">@PACKAGE_URL@</url>
+  <url type="bugtracker">@PACKAGE_BUGREPORT@</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-or-later</project_license>
+</component>

--- a/plugins/sourcecodebrowser/sourcecodebrowser/sourcecodebrowser.py
+++ b/plugins/sourcecodebrowser/sourcecodebrowser/sourcecodebrowser.py
@@ -341,7 +341,7 @@ class SourceCodeBrowserPlugin(GObject.Object, Pluma.WindowActivatable, PeasGtk.C
     """
     Source Browser Plugin for Pluma
 
-    Adds a tree view to the side panel of a Pluma window which provides a list
+    Adds a tree view to the right panel of a Pluma window which provides a list
     of programming symbols (functions, classes, variables, etc.).
     """
     __gtype_name__ = "SourceCodeBrowserPlugin"
@@ -370,7 +370,7 @@ class SourceCodeBrowserPlugin(GObject.Object, Pluma.WindowActivatable, PeasGtk.C
         self._sourcetree.sort_list = self.sort_list
         icon_dir = os.path.join(datadir, 'icons')
         icon = Gtk.Image.new_from_file(os.path.join(icon_dir, "source-code-browser.png"))
-        panel = self.window.get_side_panel()
+        panel = self.window.get_right_panel()
         panel.add_item(self._sourcetree, _("Source Code Browser"), icon)
         self._handlers = []
         hid = self._sourcetree.connect("draw", self.on_sourcetree_draw)
@@ -393,7 +393,7 @@ class SourceCodeBrowserPlugin(GObject.Object, Pluma.WindowActivatable, PeasGtk.C
         for obj, hid in self._handlers:
             obj.disconnect(hid)
         self._handlers = None
-        panel = self.window.get_side_panel()
+        panel = self.window.get_right_panel()
         panel.remove_item(self._sourcetree)
         self._sourcetree = None
 
@@ -432,8 +432,8 @@ class SourceCodeBrowserPlugin(GObject.Object, Pluma.WindowActivatable, PeasGtk.C
         """ Load the symbols for the given URI. """
         self._sourcetree.clear()
         self._is_loaded = False
-        # only load the sourcecodebrowser if it is the active tab in the side panel
-        panel = self.window.get_side_panel()
+        # only load the sourcecodebrowser if it is the active tab in the right panel
+        panel = self.window.get_right_panel()
         if not panel.item_is_active(self._sourcetree):
             return
 


### PR DESCRIPTION
This plugin uses the new right pane in Pluma to display a real-time rendering/preview of a Markdown file. It uses WebKit2 and only relies on core markdown plugins in python.

Needs python3-markdown (or whatever the lib is named in your distro).

Also moved the `sourcecodebrowser` plugin to the new right panel.

Needs https://github.com/mate-desktop/pluma/pull/718

Markdown Preview plugin:
<img width="2160" height="1289" alt="Screenshot at 2025-10-15 16-51-57" src="https://github.com/user-attachments/assets/7a92ea07-de2c-4467-afa0-fdbaa4e5e0bd" />

Source code browser plugin on right side:
<img width="3840" height="2044" alt="Screenshot at 2025-10-16 08-18-35" src="https://github.com/user-attachments/assets/bb868e5f-a8ac-4b3d-ab16-f130d6bddc46" />